### PR TITLE
Remove unused "spookie" method or variable...

### DIFF
--- a/lib/spork.rb
+++ b/lib/spork.rb
@@ -149,7 +149,6 @@ module Spork
       end
 
       def after_each_run_procs
-        spookie
         @after_each_run_procs ||= []
       end
   end


### PR DESCRIPTION
I removed "spookie" from lib/spork.rb it was present for no reason?
