### PR TITLE
default_executable= is deprecated

### DIFF
--- a/spork.gemspec
+++ b/spork.gemspec
@@ -6,7 +6,6 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Tim Harper", "Donald Parish"]
   s.date = Date.today.to_s
-  s.default_executable = %q{spork}
   s.description = %q{A forking Drb spec server}
   s.email = ["timcharper+spork@gmail.com"]
   s.executables = ["spork"]


### PR DESCRIPTION
When I ran:

`gem update --system` it brought me to version 1.7.2.  This started kicking out the following deprecation warnings:

NOTE: Gem::Specification#default_executable= is deprecated with no replacement. It will be removed on or after 2011-10-01.
Gem::Specification#default_executable= called from (eval):10
