### PR TITLE
Update docs

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -84,7 +84,7 @@ To run from the command line, use:
 
   rspec --drb spec/lib/my_spec.rb
 
-Or, you could add the following flag to your +spec.opts+ file.
+Or, you could add the following flag to your +spec.opts+ (or +.rspec+ depending on your version of rspec) file.
 
   --drb
 


### PR DESCRIPTION
putting the flag in --specs.opts didn't work needed to put it in the .rspec file. 

believe this is a result of the version of rspec you're using. I'm on 2.5.0
