### PR TITLE
Reload spork on HUP

### DIFF
--- a/bin/spork
+++ b/bin/spork
@@ -6,7 +6,15 @@ $LOAD_PATH.unshift(File.dirname(__FILE__) + '/../lib') unless $LOAD_PATH.include
 require 'spork'
 require 'spork/runner'
 
+
+trap('HUP') do
+  STDOUT.puts("HUP received, reloading...")
+  exec("#{$0} #{ARGV.map(&:shellescape).join(' ')}")
+end
+
+
 begin
+  STDOUT.puts("Starting spork, PID: #{$$}")
   success = Spork::Runner.run(ARGV, STDOUT, STDERR)
   Kernel.exit(success ? 0 : 1)
 rescue SystemExit => e


### PR DESCRIPTION
## On HUP, reload spork, keeping the same PID. Makes spork play nice with foreman.

I've been playing with foreman (https://rubygems.org/gems/foreman) lately, and wished there was an easy way to put spork in the Procfile, but still allow spork to reload if necessary.  This commit does it.

I'm not sure where the tests for the bin/spork file are, so I didn't write any.  If somebody points me there, I can update them.
