### PR TITLE
Build windows gems and Ruby gems

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -46,6 +46,13 @@ task :install_bundles do
   end
 end
 
+desc "build gems for deployment to rubygems.org"
+task :gems do
+  sh "gem build spork.gemspec"
+  sh "PLATFORM=x86-mingw32 gem build spork.gemspec"
+  sh "PLATFORM=x86-mswin32 gem build spork.gemspec"
+end
+
 # PENDING: Get this to work with gem bundler
 # desc "Test all supported versions of rails"
 # task :test_rails do

--- a/spork.gemspec
+++ b/spork.gemspec
@@ -22,6 +22,14 @@ Gem::Specification.new do |s|
   s.summary = %q{spork}
   s.test_files = Dir["features/**/*"] + Dir["spec/**/*"]
 
+  if ENV['PLATFORM']
+    s.platform = ENV['PLATFORM']
+
+    # This is probably bad since we're assuming when ENV['PLATFORM'] is set,
+    # it's windows.
+    s.add_dependency('win32-process')
+  end
+
   if s.respond_to? :specification_version then
     current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION
     s.specification_version = 3


### PR DESCRIPTION
This is a quick patch to generate gems for windows and ruby platforms.  It maintains the dependency on `win32-process` for windows machines, but it requires that when you publish gems to rubygems.org, you must publish three gems.
