### PR TITLE
Support rspec2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source :gemcutter
 gem 'cucumber', '0.10.2'
-gem "rspec", "2.5.0"
+gem 'rspec', '~> 2.6'
 gem 'rake'
 
 if RUBY_VERSION =~ /^1\.9/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: http://rubygems.org/
   specs:
+    archive-tar-minitar (0.5.2)
     builder (3.0.0)
     columnize (0.3.2)
     cucumber (0.10.2)
@@ -13,21 +14,27 @@ GEM
     gherkin (2.3.7)
       json (>= 1.4.6)
     json (1.5.1)
-    linecache (0.43)
+    linecache19 (0.5.12)
+      ruby_core_source (>= 0.1.4)
     rake (0.8.7)
-    rspec (2.5.0)
-      rspec-core (~> 2.5.0)
-      rspec-expectations (~> 2.5.0)
-      rspec-mocks (~> 2.5.0)
-    rspec-core (2.5.1)
-    rspec-expectations (2.5.0)
+    rspec (2.6.0)
+      rspec-core (~> 2.6.0)
+      rspec-expectations (~> 2.6.0)
+      rspec-mocks (~> 2.6.0)
+    rspec-core (2.6.3)
+    rspec-expectations (2.6.0)
       diff-lcs (~> 1.1.2)
-    rspec-mocks (2.5.0)
-    ruby-debug (0.10.4)
-      columnize (>= 0.1)
-      ruby-debug-base (~> 0.10.4.0)
-    ruby-debug-base (0.10.4)
-      linecache (>= 0.3)
+    rspec-mocks (2.6.0)
+    ruby-debug-base19 (0.11.25)
+      columnize (>= 0.3.1)
+      linecache19 (>= 0.5.11)
+      ruby_core_source (>= 0.1.4)
+    ruby-debug19 (0.11.6)
+      columnize (>= 0.3.1)
+      linecache19 (>= 0.5.11)
+      ruby-debug-base19 (>= 0.11.19)
+    ruby_core_source (0.1.5)
+      archive-tar-minitar (>= 0.5.2)
     term-ansicolor (1.0.5)
 
 PLATFORMS
@@ -36,5 +43,5 @@ PLATFORMS
 DEPENDENCIES
   cucumber (= 0.10.2)
   rake
-  rspec (= 2.5.0)
-  ruby-debug
+  rspec (~> 2.6)
+  ruby-debug19

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,10 @@
 require 'rubygems'
 require 'bundler'
 Bundler.setup
-require 'rake'
 
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
+
 begin
   require 'cucumber/rake/task'
   Cucumber::Rake::Task.new(:features)

--- a/lib/spork/test_framework/rspec.rb
+++ b/lib/spork/test_framework/rspec.rb
@@ -3,12 +3,16 @@ class Spork::TestFramework::RSpec < Spork::TestFramework
   HELPER_FILE = File.join(Dir.pwd, "spec/spec_helper.rb")
 
   def run_tests(argv, stderr, stdout)
-    ::Spec::Runner::CommandLine.run(
-      ::Spec::Runner::OptionParser.parse(
-        argv,
-        stderr,
-        stdout
+    if rspec1?
+      ::Spec::Runner::CommandLine.run(
+        ::Spec::Runner::OptionParser.parse(argv, stderr, stdout)
       )
-    )
+    else
+      ::RSpec::Core::CommandLine.new(argv).run(stderr, stdout)
+    end
+  end
+
+  def rspec1?
+    defined?(Spec) && !defined?(RSpec)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,113 +1,107 @@
 require 'rubygems'
 
-unless $spec_helper_loaded
-  $spec_helper_loaded = true
+SPEC_TMP_DIR = File.expand_path('tmp', File.dirname(__FILE__))
+require 'spork'
+require 'stringio'
+require 'fileutils'
+require 'rspec'
 
-  $LOAD_PATH.unshift(File.expand_path('../lib', File.dirname(__FILE__)))
-  SPEC_TMP_DIR = File.expand_path('tmp', File.dirname(__FILE__))
-  require 'spork'
-  require 'stringio'
-  require 'fileutils'
-  require 'rspec'
-
-  RSpec.configure do |config|
-    config.before(:each) do
-      $test_stdout = StringIO.new
-      $test_stderr = StringIO.new
-      @current_dir = nil
-    end
-  
-    config.after(:each) do
-      FileUtils.rm_rf(SPEC_TMP_DIR) if File.directory?(SPEC_TMP_DIR)
-    
-    end
-  
-    def create_file(filename, contents)
-      FileUtils.mkdir_p(SPEC_TMP_DIR) unless File.directory?(SPEC_TMP_DIR)
-    
-      in_current_dir do
-        FileUtils.mkdir_p(File.dirname(filename))
-        File.open(filename, 'wb') { |f| f << contents }
-      end
-    end
-
-    def create_helper_file(test_framework = FakeFramework)
-      create_file(test_framework.helper_file, "# stub spec helper file")
-    end
-
-    def in_current_dir(&block)
-      Dir.chdir(current_dir, &block)
-    end
-  
-    def current_dir
-      @current_dir ||= SPEC_TMP_DIR
-    end
-    
-    def change_current_dir(sub_path)
-      @current_dir = File.expand_path(sub_path, SPEC_TMP_DIR)
-    end
-    
-    def windows?
-      ENV['OS'] == 'Windows_NT'
-    end
+RSpec.configure do |config|
+  config.before(:each) do
+    $test_stdout = StringIO.new
+    $test_stderr = StringIO.new
+    @current_dir = nil
   end
 
+  config.after(:each) do
+    FileUtils.rm_rf(SPEC_TMP_DIR) if File.directory?(SPEC_TMP_DIR)
+  end
+end
 
-  module RSpec
-    module Matchers
-      class IncludeAStringLike
-        def initialize(substring_or_regex)
-          case substring_or_regex
-          when String
-            @regex = Regexp.new(Regexp.escape(substring_or_regex))
-          when Regexp
-            @regex = substring_or_regex
-          else
-            raise ArgumentError, "don't know what to do with the #{substring_or_regex.class} you provided"
-          end
-        end
+def create_file(filename, contents)
+  FileUtils.mkdir_p(SPEC_TMP_DIR) unless File.directory?(SPEC_TMP_DIR)
 
-        def matches?(list_of_strings)
-          @list_of_strings = list_of_strings
-          @list_of_strings.any? { |s| s =~ @regex }
-        end
-        def failure_message
-          "#{@list_of_strings.inspect} expected to include a string like #{@regex.inspect}"
-        end
-        def negative_failure_message
-          "#{@list_of_strings.inspect} expected to not include a string like #{@regex.inspect}, but did"
+  in_current_dir do
+    FileUtils.mkdir_p(File.dirname(filename))
+    File.open(filename, 'wb') { |f| f << contents }
+  end
+end
+
+def create_helper_file(test_framework = FakeFramework)
+  create_file(test_framework.helper_file, "# stub spec helper file")
+end
+
+def in_current_dir(&block)
+  Dir.chdir(current_dir, &block)
+end
+
+def current_dir
+  @current_dir ||= SPEC_TMP_DIR
+end
+
+def change_current_dir(sub_path)
+  @current_dir = File.expand_path(sub_path, SPEC_TMP_DIR)
+end
+
+def windows?
+  ENV['OS'] == 'Windows_NT'
+end
+
+
+module RSpec
+  module Matchers
+    class IncludeAStringLike
+      def initialize(substring_or_regex)
+        case substring_or_regex
+        when String
+          @regex = Regexp.new(Regexp.escape(substring_or_regex))
+        when Regexp
+          @regex = substring_or_regex
+        else
+          raise ArgumentError, "don't know what to do with the #{substring_or_regex.class} you provided"
         end
       end
 
-      def include_a_string_like(substring_or_regex)
-        IncludeAStringLike.new(substring_or_regex)
+      def matches?(list_of_strings)
+        @list_of_strings = list_of_strings
+        @list_of_strings.any? { |s| s =~ @regex }
       end
+      def failure_message
+        "#{@list_of_strings.inspect} expected to include a string like #{@regex.inspect}"
+      end
+      def negative_failure_message
+        "#{@list_of_strings.inspect} expected to not include a string like #{@regex.inspect}, but did"
+      end
+    end
+
+    def include_a_string_like(substring_or_regex)
+      IncludeAStringLike.new(substring_or_regex)
     end
   end
+end
 
-  module Spork::TestIOStreams
-    def self.included(klass)
-      klass.send(:extend, ::Spork::TestIOStreams::ClassMethods)
-    end
-  
+module Spork::TestIOStreams
+  def self.included(klass)
+    klass.send(:extend, ::Spork::TestIOStreams::ClassMethods)
+  end
+
+  def stderr
+    self.class.stderr
+  end
+
+  def stdout
+    self.class.stdout
+  end
+
+  module ClassMethods
     def stderr
-      self.class.stderr
+      $test_stderr
     end
 
     def stdout
-      self.class.stdout
-    end
-  
-    module ClassMethods
-      def stderr
-        $test_stderr
-      end
-  
-      def stdout
-        $test_stdout
-      end
+      $test_stdout
     end
   end
-
-  Dir.glob(File.dirname(__FILE__) + "/support/*.rb").each { |f| require(f) }
 end
+
+Dir.glob(File.dirname(__FILE__) + "/support/*.rb").each { |f| require(f) }

--- a/spec/spork/app_framework/rails_spec.rb
+++ b/spec/spork/app_framework/rails_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
+require 'spec_helper'
 
 describe Spork::AppFramework::Rails do
   describe ".deprecated_version" do

--- a/spec/spork/app_framework/unknown_spec.rb
+++ b/spec/spork/app_framework/unknown_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
+require 'spec_helper'
 
 describe Spork::AppFramework::Unknown do
   it "requires bootstrapping" do

--- a/spec/spork/app_framework_spec.rb
+++ b/spec/spork/app_framework_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require 'spec_helper'
 
 describe Spork::AppFramework do
   describe ".detect_framework" do

--- a/spec/spork/diagnoser_spec.rb
+++ b/spec/spork/diagnoser_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require 'spec_helper'
 
 
 describe Spork::Diagnoser do

--- a/spec/spork/forker_spec.rb
+++ b/spec/spork/forker_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require 'spec_helper'
 
 describe Spork::Forker do
   describe ".new" do
@@ -37,7 +37,7 @@ describe Spork::Forker do
       sleep 0.5
       forker.abort
       sleep 0.1
-      (ended_at - started_at).should be_close(0.5, 0.1)
+      (ended_at - started_at).should be_within(0.1).of(0.5)
       forker.running?.should == false
     end
   end

--- a/spec/spork/run_strategy/forking_spec.rb
+++ b/spec/spork/run_strategy/forking_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
+require 'spec_helper'
 
 describe Spork::RunStrategy::Forking do
   before(:each) do

--- a/spec/spork/runner_spec.rb
+++ b/spec/spork/runner_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require 'spec_helper'
 
 describe Spork::Runner do
   def use_test_server(klass = Spork::TestFramework::RSpec)

--- a/spec/spork/server_spec.rb
+++ b/spec/spork/server_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require 'spec_helper'
 
 describe Spork::Server do
   describe "a fake server" do

--- a/spec/spork/test_framework/cucumber_spec.rb
+++ b/spec/spork/test_framework/cucumber_spec.rb
@@ -1,11 +1,6 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
-require File.dirname(__FILE__) + "/../test_framework_shared_examples"
+require 'spec_helper'
+require 'spork/test_framework_shared_examples'
 
 describe Spork::TestFramework::Cucumber do
-  before(:each) do
-    @klass = Spork::TestFramework::Cucumber
-    @server = @klass.new
-  end
-
-  it_should_behave_like "a TestFramework"
+  it_behaves_like "a TestFramework"
 end

--- a/spec/spork/test_framework/rspec_spec.rb
+++ b/spec/spork/test_framework/rspec_spec.rb
@@ -3,4 +3,29 @@ require 'spork/test_framework_shared_examples'
 
 describe Spork::TestFramework::RSpec do
   it_behaves_like "a TestFramework"
+
+  it "supports rspec 1.x" do
+    begin
+      Object.const_set(:Spec, Module.new)
+      Spec.const_set(:Runner, Module.new)
+      Spec::Runner.const_set(:CommandLine, Module.new)
+      Spec::Runner.const_set(:OptionParser, Module.new)
+      Spec::Runner::OptionParser.stub(:parse)
+
+      framework = Spork::TestFramework::RSpec.new
+      framework.stub(:rspec1?).and_return(true)
+
+      Spec::Runner::CommandLine.should_receive(:run)
+
+      framework.run_tests([],StringIO.new,StringIO.new)
+    ensure
+      Object.__send__(:remove_const, :Spec)
+    end
+  end
+
+  it "supports rspec >= 2.0" do
+    RSpec::Core::CommandLine.any_instance.should_receive(:run)
+    framework = Spork::TestFramework::RSpec.new
+    framework.run_tests([],StringIO.new,StringIO.new)
+  end
 end

--- a/spec/spork/test_framework/rspec_spec.rb
+++ b/spec/spork/test_framework/rspec_spec.rb
@@ -1,10 +1,6 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
-require File.dirname(__FILE__) + "/../test_framework_shared_examples"
+require 'spec_helper'
+require 'spork/test_framework_shared_examples'
 
 describe Spork::TestFramework::RSpec do
-  before(:each) do
-    @klass = Spork::TestFramework::RSpec
-  end
-
-  it_should_behave_like "a TestFramework"
+  it_behaves_like "a TestFramework"
 end

--- a/spec/spork/test_framework_shared_examples.rb
+++ b/spec/spork/test_framework_shared_examples.rb
@@ -1,14 +1,14 @@
-shared_examples_for "a TestFramework" do
+shared_examples "a TestFramework" do
   describe ".default_port" do
     it "uses the DEFAULT_PORT when the environment variable is not set" do
-      @klass.default_port.should == @klass::DEFAULT_PORT
+      described_class.default_port.should == described_class::DEFAULT_PORT
     end
 
     it 'uses ENV["#{short_name.upcase}_DRB"] as port if present' do
-      env_name = "#{@klass.short_name.upcase}_DRB"
+      env_name = "#{described_class.short_name.upcase}_DRB"
       orig, ENV[env_name] = ENV[env_name], "9000"
       begin
-        @klass.default_port.should == 9000
+        described_class.default_port.should == 9000
       ensure
         ENV[env_name] = orig
       end
@@ -17,7 +17,7 @@ shared_examples_for "a TestFramework" do
 
   describe ".helper_file" do
     it "returns ::HELPER_FILE for the TestFramework" do
-      @klass.helper_file.should == @klass::HELPER_FILE
+      described_class.helper_file.should == described_class::HELPER_FILE
     end
   end
 end

--- a/spec/spork/test_framework_spec.rb
+++ b/spec/spork/test_framework_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require 'spec_helper'
 
 describe Spork::TestFramework do
 

--- a/spec/spork_spec.rb
+++ b/spec/spork_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+require 'spec_helper'
 
 Spork.class_eval do
   def self.reset!


### PR DESCRIPTION
Updated spork's specs to newer rspec conventions and added support for rspec 1 and rspec 2.

Right now this is monkey patched in rspec-2 directly. Assuming you accept this pull request, I'll be able to remove that monkey patch some time after you release 0.9.0.

https://github.com/rspec/rspec-core/blob/master/lib/rspec/monkey/spork/test_framework/rspec.rb
