### PR TITLE
pass string to require -- fix for RubyGems bug

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -86,7 +86,7 @@ class SporkWorld
   end
 end
 
-require(SPORK_ROOT + "features/support/bundler_helpers.rb")
+require((SPORK_ROOT + "features/support/bundler_helpers.rb").to_s)
 BundlerHelpers.set_gemfile(ENV["GEMFILE"])
 
 


### PR DESCRIPTION
I fixed this while trying to use ruby-debug to fix this: https://github.com/timcharper/spork/issues/122

I couldn't figure out how to use rdebug while running:

```
$ bundle exec cucumber features/cucumber_rails_integration.feature
```

This fix allows me to use:

```
$ rdebug cucumber -- features/diagnostic_mode.feature
```

---

SPORK_ROOT is a pathname object and the result of adding 
a string to it is a Pathname object.

RubyGems 1.6.0 through 1.8.5 pass the require path to
Regexp.escape(). In Ruby 1.9.2 passing a Pathname to
Regex.escape() throws this error:

  "can't convert Pathname to String (TypeError)"

This RubyGems bug is fixed but not yet in a release.

This bug does not show up when using bundler exec to run
cucumber feature tests -- only when using cucumber directly.
