### PR TITLE
fix cucumber-rails integration and feature test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source :gemcutter
-gem 'cucumber', '0.10.2'
+gem 'cucumber', '~> 1.0.0'
 gem 'rspec', '~> 2.6'
 gem 'rake'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,16 +4,16 @@ GEM
     archive-tar-minitar (0.5.2)
     builder (3.0.0)
     columnize (0.3.2)
-    cucumber (0.10.2)
+    cucumber (1.0.0)
       builder (>= 2.1.2)
       diff-lcs (>= 1.1.2)
-      gherkin (>= 2.3.5)
+      gherkin (~> 2.4.1)
       json (>= 1.4.6)
       term-ansicolor (>= 1.0.5)
     diff-lcs (1.1.2)
-    gherkin (2.3.7)
+    gherkin (2.4.1)
       json (>= 1.4.6)
-    json (1.5.1)
+    json (1.5.3)
     linecache19 (0.5.12)
       ruby_core_source (>= 0.1.4)
     rake (0.8.7)
@@ -41,7 +41,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cucumber (= 0.10.2)
+  cucumber (~> 1.0.0)
   rake
   rspec (~> 2.6)
   ruby-debug19

--- a/features/gemfiles/rails3.0/Gemfile
+++ b/features/gemfiles/rails3.0/Gemfile
@@ -1,7 +1,7 @@
 source :gemcutter
 gem 'sqlite3-ruby', '1.2.5'
-gem 'cucumber', '0.10.2'
-gem 'cucumber-rails', '0.4.1'
+gem 'cucumber', '~> 1.0.0'
+gem 'cucumber-rails', '~> 1.0.0'
 gem "rspec", "2.5.0"
 gem 'rspec-rails', "2.5.0"
 gem 'rails', '3.0.7'

--- a/lib/spork/test_framework/cucumber.rb
+++ b/lib/spork/test_framework/cucumber.rb
@@ -9,7 +9,7 @@ class Spork::TestFramework::Cucumber < Spork::TestFramework
 
   def preload
     require 'cucumber'
-    if ::Cucumber::VERSION >= '0.9.0'
+    if ::Cucumber::VERSION >= '0.9.0' && ::Cucumber::VERSION < '1.0.0'
       # nothing to do nowadays
     else
       preload_legacy_cucumbers
@@ -18,7 +18,7 @@ class Spork::TestFramework::Cucumber < Spork::TestFramework
   end
 
   def run_tests(argv, stderr, stdout)
-    if ::Cucumber::VERSION >= '0.9.0'
+    if ::Cucumber::VERSION >= '0.9.0'  && ::Cucumber::VERSION < '1.0.0'
       ::Cucumber::Cli::Main.new(argv, stdout, stderr).execute!
     else
       ::Cucumber::Cli::Main.new(argv, stdout, stderr).execute!(@step_mother)


### PR DESCRIPTION
See: https://github.com/timcharper/spork/issues/122

I did not commit the Gemfile.lock file used for generated rails3
application used for the cucumber-rails integration feature test.

This file does not affect the operation of spork and
will be re-generated whenever the Gemfile is updated and
the feature is run. 

FYI: the following feature/scenarios fail on the master 
branch both before and after this commit:

  features/diagnostic_mode.feature:6 
  # Scenario: Running spork --diagnose

  features/rails_delayed_loading_workarounds.feature:70 
  # Scenario: respecting custom autoload paths
