### PR TITLE
Kill all processes under JRuby/Windows

### DIFF
--- a/lib/spork/run_strategy/magazine.rb
+++ b/lib/spork/run_strategy/magazine.rb
@@ -106,22 +106,26 @@ class Spork::RunStrategy::Magazine < Spork::RunStrategy
 
   def restart_slave(id)
     pid   = @pids[id]
-    Process.kill(9, pid)
+    kill_slave(pid)
     start_slave(id)
   end
 
   def windows?
     ENV['OS'] == 'Windows_NT'
   end
+
+  def kill_slave(pid)
+    if windows?
+      system("taskkill /f /t /pid #{pid} > nul")
+    else
+      Process.kill(9, pid)
+    end
+  end
   
   def kill_all_processes
 
     @pids.each {|pid| 
-      if windows?
-        system("taskkill /f /pid #{pid}")
-      else
-        Process.kill(9, pid)
-      end
+      kill_slave(pid)
     }
     puts "\nKilling processes."; $stdout.flush
   end

--- a/lib/spork/server.rb
+++ b/lib/spork/server.rb
@@ -66,8 +66,8 @@ class Spork::Server
     
     def sig_int_received
       stdout.puts "\n"
+      abort
       if run_strategy.running?
-        abort
         stderr.puts "Running tests stopped.  Press CTRL-C again to stop the server."
         stderr.flush
       else


### PR DESCRIPTION
I'm noticing that when I run Spork under JRuby 1.6.4(ruby 1.9.2, rails 3.1) it creates a new jruby process every time I run my tests at the cost of about 100mb. In addition, these processes continue to run after I close spork with CTRL-C.

Attached a pull request that I'm currently using but couldn't run tests as they require linecache19 which has extensions which won't build under JRuby.
