### PR TITLE
quiet option for spork server

### DIFF
--- a/lib/spork/runner.rb
+++ b/lib/spork/runner.rb
@@ -22,6 +22,7 @@ module Spork
       opt.on("-b", "--bootstrap")  {|ignore| @options[:bootstrap] = true }
       opt.on("-d", "--diagnose")  {|ignore| @options[:diagnose] = true }
       opt.on("-h", "--help")  {|ignore| @options[:help] = true }
+      opt.on("-q", "--quiet")  {|ignore| @options[:quiet] = true }
       opt.on("-p", "--port [PORT]") {|port| @options[:port] = port }
       non_option_args = args.select { |arg| ! args[0].match(/^-/) }
       @options[:server_matcher] = non_option_args[0]
@@ -72,7 +73,7 @@ module Spork
       else
         run_strategy = Spork::RunStrategy.factory(test_framework)
         return(false) unless run_strategy.preload
-        Spork::Server.run(:port => @options[:port] || test_framework.default_port, :run_strategy => run_strategy)
+        Spork::Server.run(:port => @options[:port] || test_framework.default_port, :run_strategy => run_strategy, :quiet => @options[:quiet])
         return true
       end
     end

--- a/lib/spork/server.rb
+++ b/lib/spork/server.rb
@@ -14,6 +14,7 @@ class Spork::Server
   def initialize(options = {})
     @run_strategy = options[:run_strategy]
     @port = options[:port]
+    @quiet = options[:quiet]
   end
   
   def self.run(options = {})
@@ -44,9 +45,9 @@ class Spork::Server
   #
   # When implementing a test server, don't override this method: override run_tests instead.
   def run(argv, stderr, stdout)
-    puts "Running tests with args #{argv.inspect}..."
+    puts "Running tests with args #{argv.inspect}..." unless @quiet
     result = run_strategy.run(argv, stderr, stdout)
-    puts "Done.\n\n"
+    puts "Done.\n\n" unless @quiet
     result
   end
   


### PR DESCRIPTION
This adds a very simple quiet option for launching spork server to omit the "Running tests with args #{argv.inspect}..." and "Done.\n\n" 

at the command line:

```
    spork --quiet
    spork -q
```

Mostly useful with guard-spork to help having better output in the terminal
Here's the related pull request that allows a quiet option to be specified on guard-spork:
https://github.com/guard/guard-spork/pull/58
