### PR TITLE
update gemspec to add 'assets' folder (with bootstrap.rb template file)

### DIFF
--- a/spork.gemspec
+++ b/spork.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
     "MIT-LICENSE",
      "README.rdoc"
   ]
-  s.files = ["Gemfile", "README.rdoc", "MIT-LICENSE"] + Dir["lib/**/*"] + Dir["spec/**/*"] + Dir["features/**/*"]
+  s.files = ["Gemfile", "README.rdoc", "MIT-LICENSE"] + Dir["lib/**/*"] + Dir["spec/**/*"] + Dir["features/**/*"] + Dir["assets/**/*"]
   s.homepage = %q{http://github.com/sporkrb/spork}
   s.rdoc_options = ["--main", "README.rdoc"]
   s.require_paths = ["lib"]


### PR DESCRIPTION
`assets` folder was not included in the gemspec (so, not installed with the gem), and the bootstrap template file (`assets/bootstrap.rb`) wasn't there. So, it can't be found while executing `spork --bootstrap`.
