### PR TITLE
Test to differentiate between rspec 1 and 2 was wrong

### DIFF
--- a/lib/spork/test_framework/rspec.rb
+++ b/lib/spork/test_framework/rspec.rb
@@ -13,6 +13,6 @@ class Spork::TestFramework::RSpec < Spork::TestFramework
   end
 
   def rspec1?
-    defined?(Spec) && !defined?(RSpec)
+    defined?(::Spec) && !defined?(::RSpec)
   end
 end


### PR DESCRIPTION
I think defined?(RSpec) was always true because this class was defined within Spork module. Here's a fix.
