### PR TITLE
V0.9.x - Allow multiple forks to run in parallel and provide a counter to each fork

### DIFF
--- a/lib/spork.rb
+++ b/lib/spork.rb
@@ -13,16 +13,19 @@ module Spork
   autoload :Diagnoser,     (LIBDIR + 'spork/diagnoser').to_s
   autoload :GemHelpers,    (LIBDIR + 'spork/gem_helpers').to_s
 
-  @process_counter_semaphore = Mutex.new
+  @run_count_semaphore = Mutex.new
 
   class << self
 
-    def process_counter
-      @process_counter || 0
+    def run_count
+      @run_count || 0
     end
 
-    def process_counter=(counter)
-      @process_counter = counter
+    def increase_run_count
+      @run_count_semaphore.synchronize do
+        @run_count = 0 unless @run_count
+        @run_count += 1
+      end
     end
 
     # Run a block, during prefork mode.  By default, if prefork is called twice in the same file and line number, the supplied block will only be ran once.
@@ -46,12 +49,6 @@ module Spork
         each_run_procs << block
       else
         yield
-      end
-    end
-
-    def increase_process_counter
-      @process_counter_semaphore.synchronize do
-        self.process_counter += 1
       end
     end
 

--- a/lib/spork/run_strategy/forking.rb
+++ b/lib/spork/run_strategy/forking.rb
@@ -6,6 +6,8 @@ class Spork::RunStrategy::Forking < Spork::RunStrategy
   def run(argv, stderr, stdout)
     abort if running?
 
+    Spork.increase_process_counter
+
     @child = ::Spork::Forker.new do
       $stdout, $stderr = stdout, stderr
       load test_framework.helper_file

--- a/lib/spork/run_strategy/forking.rb
+++ b/lib/spork/run_strategy/forking.rb
@@ -4,7 +4,7 @@ class Spork::RunStrategy::Forking < Spork::RunStrategy
   end
 
   def run(argv, stderr, stdout)
-    Spork.increase_process_counter
+    Spork.increase_run_count
 
     child = ::Spork::Forker.new do
       $stdout, $stderr = stdout, stderr

--- a/lib/spork/run_strategy/forking.rb
+++ b/lib/spork/run_strategy/forking.rb
@@ -4,11 +4,9 @@ class Spork::RunStrategy::Forking < Spork::RunStrategy
   end
 
   def run(argv, stderr, stdout)
-    abort if running?
-
     Spork.increase_process_counter
 
-    @child = ::Spork::Forker.new do
+    child = ::Spork::Forker.new do
       $stdout, $stderr = stdout, stderr
       load test_framework.helper_file
       Spork.exec_each_run
@@ -16,19 +14,11 @@ class Spork::RunStrategy::Forking < Spork::RunStrategy
       Spork.exec_after_each_run
       result
     end
-    @child.result
-  end
-
-  def abort
-    @child && @child.abort
+    child.result
   end
 
   def preload
     test_framework.preload
-  end
-
-  def running?
-    @child && @child.running?
   end
 
   def assert_ready!

--- a/spec/spork/run_strategy/forking_spec.rb
+++ b/spec/spork/run_strategy/forking_spec.rb
@@ -13,17 +13,6 @@ describe Spork::RunStrategy::Forking do
     @run_strategy.run("test", STDOUT, STDIN).should == "tests were ran"
   end
 
-  it "aborts the current running thread when another run is started" do
-    create_helper_file
-    @fake_framework.wait_time = 0.25
-    first_run = Thread.new { @run_strategy.run("test", STDOUT, STDIN).should == nil }
-    sleep(0.05)
-    @run_strategy.run("test", STDOUT, STDIN).should == true
-
-    # wait for the first to finish
-    first_run.join
-  end
-
   it "can abort the current run" do
     create_helper_file
     @fake_framework.wait_time = 5


### PR DESCRIPTION
Address #164
- Do not abort a run if another run is wanted.
- Do kill all forks if spork is terminating
- Provide Spork.run_count so each process know some thing about it. This allow the rotation of database connections for running test in parallel (I'm working on this: https://github.com/phuongnd08/multi_spork)
