### PR TITLE
Make max slaves number in magzine mode configurable

### DIFF
--- a/lib/spork/run_strategy/magazine.rb
+++ b/lib/spork/run_strategy/magazine.rb
@@ -19,7 +19,7 @@ require 'magazine/magazine_slave'
 
 class Spork::RunStrategy::Magazine < Spork::RunStrategy
 
-  Slave_Id_Range = 1..2 # Ringserver uses id: 0. Slave use: 1..MAX_SLAVES
+  Slave_Id_Range = 1..(ENV['MAX_SLAVES'] || 2).to_i # Ringserver uses id: 0. Slave use: 1..MAX_SLAVES
 
   def slave_max
     Slave_Id_Range.to_a.size


### PR DESCRIPTION
I am using spork for unit testing in a JRuby Rails project. I found the default 2 slaves in magazine mode is not big enough for a fast TDD rhythm. I frequently found I used up two of slave node and get a "- NO tuple" error. So I put in a environment variable called MAX_SLAVES to configure it(default is still 2). MAX_SLAVES=6 works perfectly for me.
