### PR TITLE
Avoid IO errors and output in the specs 

### DIFF
--- a/spec/spork/run_strategy/forking_spec.rb
+++ b/spec/spork/run_strategy/forking_spec.rb
@@ -4,7 +4,6 @@ describe Spork::RunStrategy::Forking do
   before(:each) do
     @fake_framework = FakeFramework.new
     @run_strategy = Spork::RunStrategy::Forking.new(@fake_framework)
-
   end
 
   it "returns the result of the run_tests method from the forked child" do


### PR DESCRIPTION
1. Makes sure the second argument to #run is writable.
2. Makes the third argument a null sink in order to avoid output when the runs are aborted.
### Before:

```
~/Projects/spork $ rspec                                                                                                                                                 (master)
.............../Users/dasch/Projects/spork/lib/spork/forker.rb:27:in `write': not opened for writing (IOError)
    from /Users/dasch/Projects/spork/lib/spork/forker.rb:27:in `puts'
    from /Users/dasch/Projects/spork/lib/spork/forker.rb:27:in `puts'
    from /Users/dasch/Projects/spork/lib/spork/forker.rb:27:in `rescue in block in initialize'
    from /Users/dasch/Projects/spork/lib/spork/forker.rb:19:in `block in initialize'
    from /Users/dasch/Projects/spork/lib/spork/forker.rb:18:in `fork'
    from /Users/dasch/Projects/spork/lib/spork/forker.rb:18:in `initialize'
    from /Users/dasch/Projects/spork/lib/spork/run_strategy/forking.rb:9:in `new'
    from /Users/dasch/Projects/spork/lib/spork/run_strategy/forking.rb:9:in `run'
    from /Users/dasch/Projects/spork/spec/spork/run_strategy/forking_spec.rb:19:in `block (3 levels) in <top (required)>'
./Users/dasch/Projects/spork/lib/spork/forker.rb:27:in `write': not opened for writing (IOError)
    from /Users/dasch/Projects/spork/lib/spork/forker.rb:27:in `puts'
    from /Users/dasch/Projects/spork/lib/spork/forker.rb:27:in `puts'
    from /Users/dasch/Projects/spork/lib/spork/forker.rb:27:in `rescue in block in initialize'
    from /Users/dasch/Projects/spork/lib/spork/forker.rb:19:in `block in initialize'
    from /Users/dasch/Projects/spork/lib/spork/forker.rb:18:in `fork'
    from /Users/dasch/Projects/spork/lib/spork/forker.rb:18:in `initialize'
    from /Users/dasch/Projects/spork/lib/spork/run_strategy/forking.rb:9:in `new'
    from /Users/dasch/Projects/spork/lib/spork/run_strategy/forking.rb:9:in `run'
    from /Users/dasch/Projects/spork/spec/spork/run_strategy/forking_spec.rb:31:in `block (3 levels) in <top (required)>'
....................................

Finished in 1.57 seconds
52 examples, 0 failures
```
### After:

```
~/Projects/spork $ rspec                                                                                                                                       (fix-test-failure)
....................................................

Finished in 1.58 seconds
52 examples, 0 failures
```
