### PR TITLE
Patch for Rinda::RingFinger in Ruby 1.9.

### DIFF
--- a/lib/spork/run_strategy/magazine.rb
+++ b/lib/spork/run_strategy/magazine.rb
@@ -16,6 +16,7 @@ require 'rubygems' # used for Gem.ruby
 
 $:.unshift(File.dirname(__FILE__))
 require 'magazine/magazine_slave'
+require 'magazine/rinda_ring_finger_patch' if RUBY_VERSION > '1.9.1'
 
 class Spork::RunStrategy::Magazine < Spork::RunStrategy
 

--- a/lib/spork/run_strategy/magazine/magazine_slave_provider.rb
+++ b/lib/spork/run_strategy/magazine/magazine_slave_provider.rb
@@ -1,6 +1,7 @@
 # magazine_slave_provider.rb
 require 'drb'
 require 'rinda/ring'
+require './rinda_ring_finger_patch' if RUBY_VERSION > '1.9.1'
 require 'rinda/tuplespace'
 require './magazine_slave'
 

--- a/lib/spork/run_strategy/magazine/rinda_ring_finger_patch.rb
+++ b/lib/spork/run_strategy/magazine/rinda_ring_finger_patch.rb
@@ -1,0 +1,26 @@
+# Patch for Rinda::RingFinger.primary hanging forever on Ruby 1.9.2 & 1.9.3
+# from http://www.ruby-forum.com/topic/4229908
+require 'rinda/ring'
+
+module Rinda
+  class RingFinger
+    def lookup_ring_any(timeout=5)
+      queue = Queue.new
+
+      Thread.new do
+        self.lookup_ring(timeout) do |ts|
+          queue.push(ts)
+        end
+        queue.push(nil)
+      end
+
+      @primary = queue.pop
+      raise('RingNotFound') if @primary.nil?
+      while it = queue.pop
+        @rings.push(it)
+      end
+
+      @primary
+    end
+  end
+end

--- a/lib/spork/run_strategy/magazine/ring_server.rb
+++ b/lib/spork/run_strategy/magazine/ring_server.rb
@@ -1,5 +1,6 @@
 # ring_server.rb
 require 'rinda/ring'
+require './rinda_ring_finger_patch' if RUBY_VERSION > '1.9.1'
 require 'rinda/tuplespace'
 
 DRb.start_service


### PR DESCRIPTION
Rinda::RingFinger.primary hangs sometimes forever. This is even broken in Ruby 1.9.3p194 and the applied patch fixes it.

Patch itself is from http://www.ruby-forum.com/topic/4229908
