### PR TITLE
Add support for specifying max slave count via SPORK_SLAVES_COUNT

### DIFF
--- a/lib/spork/run_strategy/magazine.rb
+++ b/lib/spork/run_strategy/magazine.rb
@@ -19,7 +19,7 @@ require 'magazine/magazine_slave'
 
 class Spork::RunStrategy::Magazine < Spork::RunStrategy
 
-  Slave_Id_Range = 1..2 # Ringserver uses id: 0. Slave use: 1..MAX_SLAVES
+  Slave_Id_Range = 1..(ENV["SPORK_SLAVES_COUNT"] && ENV["SPORK_SLAVES_COUNT"].to_i || 2) # Ringserver uses id: 0. Slave use: 1..MAX_SLAVES
 
   def slave_max
     Slave_Id_Range.to_a.size


### PR DESCRIPTION
Add support for specifying max magazine slave count via `SPORK_SLAVES_COUNT` environment variable.
