### PR TITLE
Please pull fix for Rspec1

### DIFF
--- a/lib/spork/test_framework/rspec.rb
+++ b/lib/spork/test_framework/rspec.rb
@@ -13,6 +13,6 @@ class Spork::TestFramework::RSpec < Spork::TestFramework
   end
 
   def rspec1?
-    defined?(Spec) && !defined?(RSpec)
+    defined?(::Spec) && !defined?(::RSpec)
   end
 end


### PR DESCRIPTION
Please pull fix for Rspec1 - This is a merge of soup/master with the current sporkrb/spork master. I have checked the fix works for my rails 2.3 project.

Merging this into the official spork will also affect rubymine because it checks the a standard spork gem has been installed before running spork (ignoring gems installed from git repositories as bundle hides them from the standard list).
