### PR TITLE
Don't print stack trace on SystemExit exception.

### DIFF
--- a/lib/spork/forker.rb
+++ b/lib/spork/forker.rb
@@ -24,7 +24,9 @@ class Spork::Forker
       rescue EOFError
         nil
       rescue Exception => e
-        puts "Exception encountered: #{e.inspect}\nbacktrace:\n#{e.backtrace * %(\n)}"
+        unless e.class == SystemExit
+          puts "Exception encountered: #{e.inspect}\nbacktrace:\n#{e.backtrace * %(\n)}"
+        end
       end
       
       # terminate, skipping any at_exit blocks.


### PR DESCRIPTION
This fixes undesired stack trace dumping when Cucumber process exits.  Cucumber 1.3.0 changed its exit strategy here https://github.com/cucumber/cucumber/commit/21e3dbb2b4081376f16d6f3e01d8f26c0d7b1740#diff-13
