### PR TITLE
Handle SystemExit in the magazine run strategy (thrown by Cucumber 1.3.1...

### DIFF
--- a/lib/spork/run_strategy/magazine/magazine_slave.rb
+++ b/lib/spork/run_strategy/magazine/magazine_slave.rb
@@ -19,7 +19,11 @@ class MagazineSlave
     $stdout, $stderr = stdout, stderr
     Spork.exec_each_run
     load @test_framework.helper_file
-    @test_framework.run_tests(argv, stderr, stdout)
+    begin
+      @test_framework.run_tests(argv, stderr, stdout)
+    rescue SystemExit => e
+      puts "Error: exit code #{e.status}" unless e.status == 0
+    end
     puts "  <-- Slave(#{@id_num}) run done!"; stdout.flush
   end
 


### PR DESCRIPTION
...).
This is the Magazine version of the fix already made to the forker.rb in commit 38ab44f0968c23509912680a04f903fe4ad5c068 for Cucumber 1.3 support.
