### PR TITLE
make s.date into a Date object (not a string)

### DIFF
--- a/spork.gemspec
+++ b/spork.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Tim Harper", "Donald Parish"]
-  s.date = Date.today.to_s
+  s.date = File.atime("spork.gemspec")
   s.description = %q{A forking Drb spec server}
   s.email = ["timcharper+spork@gmail.com"]
   s.executables = ["spork"]


### PR DESCRIPTION
fix for this error I am getting:
23:54:34 ++ ruby -I vendor/gems/bundler/lib vendor/gems/bundler/bin/bundle exec rake db:rebuild
23:54:35 Invalid gemspec in [/var/lib/jenkins/gems/job-peacock_sandbox-5659/specifications/spork-1.0.0rc2.gemspec]: invalid date format in specification: "2012-02-08 00:00:00.000000000Z"
23:54:35 Invalid gemspec in [/var/lib/jenkins/gems/job-peacock_sandbox-5659/specifications/spork-1.0.0rc2.gemspec]: invalid date format in specification: "2012-02-08 00:00:00.000000000Z"
23:54:35 Invalid gemspec in [/var/lib/jenkins/gems/job-peacock_sandbox-5659/specifications/spork-1.0.0rc2.gemspec]: invalid date format in specification: "2012-02-08 00:00:00.000000000Z"
23:54:35 Invalid gemspec in [/var/lib/jenkins/gems/job-peacock_sandbox-5659/specifications/spork-1.0.0rc2.gemspec]: invalid date format in specification: "2012-02-08 00:00:00.000000000Z"
23:54:35 Invalid gemspec in [/var/lib/jenkins/gems/job-peacock_sandbox-5659/specifications/spork-1.0.0rc2.gemspec]: invalid date format in specification: "2012-02-08 00:00:00.000000000Z"
23:54:36 Invalid gemspec in [/var/lib/jenkins/gems/job-peacock_sandbox-5659/specifications/spork-1.0.0rc2.gemspec]: invalid date format in specification: "2012-02-08 00:00:00.000000000Z"
23:54:36 Invalid gemspec in [/var/lib/jenkins/gems/job-peacock_sandbox-5659/specifications/spork-1.0.0rc2.gemspec]: invalid date format in specification: "2012-02-08 00:00:00.000000000Z"
23:54:36 Invalid gemspec in [/var/lib/jenkins/gems/job-peacock_sandbox-5659/specifications/spork-1.0.0rc2.gemspec]: invalid date format in specification: "2012-02-08 00:00:00.000000000Z"
23:54:36 Invalid gemspec in [/var/lib/jenkins/gems/job-peacock_sandbox-5659/specifications/spork-1.0.0rc2.gemspec]: invalid date format in specification: "2012-02-08 00:00:00.000000000Z"
