### PR TITLE
Specify helper file via environment variable

### DIFF
--- a/lib/spork/test_framework.rb
+++ b/lib/spork/test_framework.rb
@@ -50,7 +50,7 @@ class Spork::TestFramework
   end
 
   def self.helper_file
-    self::HELPER_FILE
+    ENV["#{short_name.upcase}_HELPER_FILE"] || self::HELPER_FILE
   end
 
   def self.default_port

--- a/spec/spork/test_framework_shared_examples.rb
+++ b/spec/spork/test_framework_shared_examples.rb
@@ -19,5 +19,15 @@ shared_examples "a TestFramework" do
     it "returns ::HELPER_FILE for the TestFramework" do
       described_class.helper_file.should == described_class::HELPER_FILE
     end
+
+    it 'uses ENV["#{short_name.upcase}_HELPER_FILE"] as helper file if present' do
+      env_name = "#{described_class.short_name.upcase}_HELPER_FILE"
+      orig, ENV[env_name] = ENV[env_name], "spec_integration/integration_helper.rb"
+      begin
+        described_class.helper_file.should == "spec_integration/integration_helper.rb"
+      ensure
+        ENV[env_name] = orig
+      end
+    end
   end
 end


### PR DESCRIPTION
In a very similar way to the one used to specify a port.

In our project, we need to maintain regular specs and integration specs completely separated (as in, two different `spec_helper`s that are never loaded at the same time, and running the specs in different processes). As spork hardcodes the path to `spec_helper`, we can not run a second spork server with the second helper file loaded instead. This change would allow it.
