### PR TITLE
Update rspec syntax to use 'expect' and also change '==' to 'eq' and '=~' to 'match'

### DIFF
--- a/spec/spork/app_framework_spec.rb
+++ b/spec/spork/app_framework_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Spork::AppFramework do
   describe ".detect_framework" do
     it "returns Unknown when no framework known detected" do
-      Spork::AppFramework.detect_framework.short_name.should == "Unknown"
+      expect(Spork::AppFramework.detect_framework.short_name).to eq "Unknown"
     end
   end
 end

--- a/spec/spork/diagnoser_spec.rb
+++ b/spec/spork/diagnoser_spec.rb
@@ -5,7 +5,7 @@ describe Spork::Diagnoser do
     Spork::Diagnoser.remove_hook!
     Spork::Diagnoser.loaded_files.clear
   end
-  
+
   def run_simulation(directory, filename = nil, contents = nil, &block)
     FileUtils.mkdir_p(directory)
     Dir.chdir(directory) do
@@ -17,17 +17,17 @@ describe Spork::Diagnoser do
       yield if block_given?
     end
   end
-  
+
   it "installs it's hook and tells you when files have been loaded" do
     run_simulation(SPEC_TMP_DIR, 'my_awesome_library_include.rb', '1 + 5')
-    Spork::Diagnoser.loaded_files.keys.should include_a_string_like('my_awesome_library_include')
+    expect(Spork::Diagnoser.loaded_files.keys).to include_a_string_like('my_awesome_library_include')
   end
 
   it 'excludes files outside of Dir.pwd' do
     run_simulation(SPEC_TMP_DIR + '/project_root', '../external_dependency.rb', '1 + 5')
-    Spork::Diagnoser.loaded_files.keys.should_not include_a_string_like('external_dependency')
+    expect(Spork::Diagnoser.loaded_files.keys).to_not include_a_string_like('external_dependency')
   end
-  
+
   it "excludes files outside of Dir.pwd but in ruby's include path" do
     directory = SPEC_TMP_DIR + '/project_root'
     external_dependency_dir = SPEC_TMP_DIR + '/external_dependency'
@@ -39,11 +39,11 @@ describe Spork::Diagnoser do
       Spork::Diagnoser.install_hook!
       require 'the_most_awesome_external_dependency_ever'
     end
-    
-    Spork::Diagnoser.loaded_files.keys.should_not include_a_string_like('the_most_awesome_external_dependency_ever')
+
+    expect(Spork::Diagnoser.loaded_files.keys).to_not include_a_string_like('the_most_awesome_external_dependency_ever')
     $:.pop
   end
-  
+
   it "expands files to their fully their fully qualified path" do
     directory = SPEC_TMP_DIR + '/project_root'
     lib_directory = directory + '/lib'
@@ -54,11 +54,11 @@ describe Spork::Diagnoser do
       Spork::Diagnoser.install_hook!
       require 'the_most_awesome_lib_file_ever'
     end
-    
-    Spork::Diagnoser.loaded_files.keys.should include_a_string_like('lib/the_most_awesome_lib_file_ever')
+
+    expect(Spork::Diagnoser.loaded_files.keys).to include_a_string_like('lib/the_most_awesome_lib_file_ever')
     $:.pop
   end
-  
+
   it "can tell the difference between a folder in the project path and a file in an external path" do
     directory = SPEC_TMP_DIR + '/project_root'
     external_dependency_dir = SPEC_TMP_DIR + '/external_dependency'
@@ -71,11 +71,11 @@ describe Spork::Diagnoser do
       Spork::Diagnoser.install_hook!
       require 'a_popular_folder_name'
     end
-    
-    Spork::Diagnoser.loaded_files.keys.should_not include_a_string_like('a_popular_folder_name')
+
+    expect(Spork::Diagnoser.loaded_files.keys).to_not include_a_string_like('a_popular_folder_name')
     $:.pop
   end
-  
+
   it "filters backtrace beyond the last line matching the entry point" do
     Spork::Diagnoser.install_hook!("test_filter/environment.rb")
     create_file("test_filter/environment.rb", "require './test_filter/app.rb'")
@@ -85,20 +85,20 @@ describe Spork::Diagnoser do
       require './test_filter/environment.rb'
     end
     f = Spork::Diagnoser.loaded_files
-    f[f.keys.grep(/app.rb/).first].last.should include('test_filter/environment.rb')
-    f[f.keys.grep(/my_model.rb/).first].last.should include('test_filter/environment.rb')
-    f[f.keys.grep(/environment.rb/).first].should == []
+    expect(f[f.keys.grep(/app.rb/).first].last).to include('test_filter/environment.rb')
+    expect(f[f.keys.grep(/my_model.rb/).first].last).to include('test_filter/environment.rb')
+    expect(f[f.keys.grep(/environment.rb/).first]).to eq []
   end
-  
+
   describe ".output_results" do
     it "outputs the results relative to the current directory" do
       Spork::Diagnoser.loaded_files["/project_path/lib/file.rb"] = ["/project_path/lib/parent_file.rb:35"]
       Dir.stub!(:pwd).and_return("/project_path")
       out = StringIO.new
       Spork::Diagnoser.output_results(out)
-      out.string.should =~ %r([^/]lib/file.rb)
-      out.string.should =~ %r([^/]lib/parent_file.rb)
-      out.string.should_not include("/project_path/")
+      expect(out.string).to match( %r([^/]lib/file.rb) )
+      expect(out.string).to match( %r([^/]lib/parent_file.rb) )
+      expect(out.string).to_not include("/project_path/")
     end
   end
 end

--- a/spec/spork/forker_spec.rb
+++ b/spec/spork/forker_spec.rb
@@ -5,23 +5,23 @@ describe Spork::Forker do
     it "runs a block in a fork" do
       $var = "hello world"
       Spork::Forker.new { $var = "booyah" }.result
-      $var.should == "hello world"
+      expect($var).to eq "hello world"
     end
   end
   
   describe "#result" do
     it "returns the result" do
-      Spork::Forker.new { "results" }.result.should == "results"
+      expect(Spork::Forker.new { "results" }.result).to eq "results"
     end
   end
   
   describe "#running?" do
     it "reports when the fork is running" do
       forker = Spork::Forker.new { sleep 0.1 }
-      forker.running?.should == true
+      expect(forker.running?).to eq true
       forker.result
       sleep 0.1
-      forker.running?.should == false
+      expect(forker.running?).to eq false
     end
   end
   
@@ -36,14 +36,14 @@ describe Spork::Forker do
         end
       end
       Thread.new do
-        forker.result.should == nil
+        expect(forker.result).to eq nil
         ended_at = Time.now
       end
       sleep 0.5
       forker.abort
       sleep 0.1
-      (ended_at - started_at).should be_within(0.1).of(0.5)
-      forker.running?.should == false
+      expect((ended_at - started_at)).to be_within(0.1).of(0.5)
+      expect(forker.running?).to eq false
     end
   end
 end unless windows?

--- a/spec/spork/runner_spec.rb
+++ b/spec/spork/runner_spec.rb
@@ -9,42 +9,42 @@ describe Spork::Runner do
   before(:each) do
     @out, @err = StringIO.new, StringIO.new
   end
-  
+
   it "finds a matching server with a prefix" do
-    Spork::Runner.new(["rs"], @out, @err).find_test_framework.class.should == Spork::TestFramework::RSpec
+    expect(Spork::Runner.new(["rs"], @out, @err).find_test_framework.class).to eq Spork::TestFramework::RSpec
   end
-  
+
   it "shows an error message if no matching server was found" do
-    Spork::Runner.new(["argle_bargle"], @out, @err).run.should == false
-    @err.string.should include(%(Couldn't find a supported test framework that begins with 'argle_bargle'))
+    expect(Spork::Runner.new(["argle_bargle"], @out, @err).run).to eq false
+    expect(@err.string).to include(%(Couldn't find a supported test framework that begins with 'argle_bargle'))
   end
-  
+
   it "bootstraps a server when -b is passed in" do
     use_test_server
     @test_framework.should_receive(:bootstrap)
     Spork::Runner.new(['rspec', '-b'], @out, @err).run
   end
-  
+
   it "aborts if it can't preload" do
     use_test_server
     @test_framework.should_receive(:preload).and_return(false)
     Spork::Server.should_not_receive(:run)
     Spork::Runner.new(['rspec'], @out, @err).run
   end
-  
+
   it "runs the server if all is well" do
     use_test_server
     @test_framework.should_receive(:preload).and_return(true)
     Spork::Server.should_receive(:run)
     Spork::Runner.new(['rspec'], @out, @err).run
-    @err.string.should include("Using RSpec")
+    expect(@err.string).to include("Using RSpec")
   end
-  
+
   it "outputs a list of supported servers, along with supported asterisk" do
     Spork::Server.stub!(:supported_test_frameworks).and_return([Spork::TestFramework::RSpec, Spork::TestFramework::Cucumber])
     Spork::TestFramework::RSpec.stub!(:available?).and_return(true)
     Spork::TestFramework::Cucumber.stub!(:available?).and_return(false)
-    
-    Spork::Runner.new(['rspec'], @out, @err).supported_test_frameworks_text.should include("(*) RSpec")
+
+    expect(Spork::Runner.new(['rspec'], @out, @err).supported_test_frameworks_text).to include("(*) RSpec")
   end
 end

--- a/spec/spork/server_spec.rb
+++ b/spec/spork/server_spec.rb
@@ -9,7 +9,7 @@ describe Spork::Server do
     
     it "accepts a port" do
       @server.port = 12345
-      @server.port.should == 12345
+      expect(@server.port).to eq 12345
     end
   end
 end

--- a/spec/spork/test_framework_spec.rb
+++ b/spec/spork/test_framework_spec.rb
@@ -12,42 +12,42 @@ describe Spork::TestFramework do
     end
 
     it "returns a list of all available servers" do
-      Spork::TestFramework.available_test_frameworks.should == []
+      expect(Spork::TestFramework.available_test_frameworks).to eq []
       Spork::TestFramework::RSpec.stub!(:available?).and_return(true)
-      Spork::TestFramework.available_test_frameworks.should == [Spork::TestFramework::RSpec]
+      expect(Spork::TestFramework.available_test_frameworks).to eq [Spork::TestFramework::RSpec]
     end
 
     it "returns rspec before cucumber when both are available" do
       Spork::TestFramework::RSpec.stub!(:available?).and_return(true)
       Spork::TestFramework::Cucumber.stub!(:available?).and_return(true)
-      Spork::TestFramework.available_test_frameworks.should == [Spork::TestFramework::RSpec, Spork::TestFramework::Cucumber]
+      expect(Spork::TestFramework.available_test_frameworks).to eq [Spork::TestFramework::RSpec, Spork::TestFramework::Cucumber]
     end
   end
 
   describe ".supported_test_frameworks" do
     it "returns all defined servers" do
-      Spork::TestFramework.supported_test_frameworks.should include(Spork::TestFramework::RSpec)
-      Spork::TestFramework.supported_test_frameworks.should include(Spork::TestFramework::Cucumber)
+      expect(Spork::TestFramework.supported_test_frameworks).to include(Spork::TestFramework::RSpec)
+      expect(Spork::TestFramework.supported_test_frameworks).to include(Spork::TestFramework::Cucumber)
     end
 
     it "returns a list of servers matching a case-insensitive prefix" do
-      Spork::TestFramework.supported_test_frameworks("rspec").should == [Spork::TestFramework::RSpec]
-      Spork::TestFramework.supported_test_frameworks("rs").should == [Spork::TestFramework::RSpec]
-      Spork::TestFramework.supported_test_frameworks("cuc").should == [Spork::TestFramework::Cucumber]
+      expect(Spork::TestFramework.supported_test_frameworks("rspec")).to eq [Spork::TestFramework::RSpec]
+      expect(Spork::TestFramework.supported_test_frameworks("rs")).to eq [Spork::TestFramework::RSpec]
+      expect(Spork::TestFramework.supported_test_frameworks("cuc")).to eq [Spork::TestFramework::Cucumber]
     end
   end
 
   describe ".short_name" do
     it "returns the name of the framework, without the namespace prefix" do
-      Spork::TestFramework::Cucumber.short_name.should == "Cucumber"
+      expect(Spork::TestFramework::Cucumber.short_name).to eq "Cucumber"
     end
   end
 
   describe ".available?" do
     it "returns true when the helper_file exists" do
-      FakeFramework.available?.should == false
+      expect(FakeFramework.available?).to eq false
       create_helper_file(FakeFramework)
-      FakeFramework.available?.should == true
+      expect(FakeFramework.available?).to eq true
     end
   end
 
@@ -55,9 +55,9 @@ describe Spork::TestFramework do
     it "recognizes if the helper_file has been bootstrapped" do
       bootstrap_contents = File.read(FakeFramework::BOOTSTRAP_FILE)
       File.stub!(:read).with(@fake.helper_file).and_return("")
-      @fake.bootstrapped?.should == false
+      expect(@fake.bootstrapped?).to eq false
       File.stub!(:read).with(@fake.helper_file).and_return(bootstrap_contents)
-      @fake.bootstrapped?.should == true
+      expect(@fake.bootstrapped?).to eq true
     end
   end
 
@@ -66,11 +66,11 @@ describe Spork::TestFramework do
       create_helper_file
       @fake.bootstrap
 
-      TestIOStreams.stderr.string.should include("Bootstrapping")
-      TestIOStreams.stderr.string.should include("Edit")
-      TestIOStreams.stderr.string.should include("favorite text editor")
+      expect(TestIOStreams.stderr.string).to include("Bootstrapping")
+      expect(TestIOStreams.stderr.string).to include("Edit")
+      expect(TestIOStreams.stderr.string).to include("favorite text editor")
 
-      File.read(@fake.helper_file).should include(File.read(FakeFramework::BOOTSTRAP_FILE))
+      expect(File.read(@fake.helper_file)).to include(File.read(FakeFramework::BOOTSTRAP_FILE))
     end
   end
 
@@ -78,13 +78,13 @@ describe Spork::TestFramework do
     it "defaults to use rspec over cucumber" do
       Spork::TestFramework::RSpec.stub!(:available?).and_return(true)
       Spork::TestFramework::Cucumber.stub!(:available?).and_return(true)
-      Spork::TestFramework.factory(STDOUT, STDERR).class.should == Spork::TestFramework::RSpec
+      expect(Spork::TestFramework.factory(STDOUT, STDERR).class).to eq Spork::TestFramework::RSpec
     end
 
     it "defaults to use cucumber when rspec not available" do
       Spork::TestFramework::RSpec.stub!(:available?).and_return(false)
       Spork::TestFramework::Cucumber.stub!(:available?).and_return(true)
-      Spork::TestFramework.factory(STDOUT, STDERR).class.should == Spork::TestFramework::Cucumber
+      expect(Spork::TestFramework.factory(STDOUT, STDERR).class).to eq Spork::TestFramework::Cucumber
     end
   end
 end

--- a/spec/spork_spec.rb
+++ b/spec/spork_spec.rb
@@ -28,19 +28,19 @@ describe Spork do
   
   it "only runs the preload block when preforking" do
     Spork.exec_prefork { spec_helper_simulator }
-    @ran.should == [:prefork]
+    expect(@ran).to eq [:prefork]
   end
   
   it "only runs the each_run block when running" do
     Spork.exec_prefork { spec_helper_simulator }
-    @ran.should == [:prefork]
+    expect(@ran).to eq [:prefork]
     
     Spork.exec_each_run
-    @ran.should == [:prefork, :each_run]
+    expect(@ran).to eq [:prefork, :each_run]
   end
   
   it "runs both blocks when Spork not activated" do
-    spec_helper_simulator.should == [:prefork, :each_run]
+    expect(spec_helper_simulator).to eq [:prefork, :each_run]
   end
   
   it "prevents blocks from being ran twice" do
@@ -49,24 +49,24 @@ describe Spork do
     @ran.clear
     Spork.exec_prefork { spec_helper_simulator }
     Spork.exec_each_run
-    @ran.should == []
+    expect(@ran).to eq []
   end
   
   it "runs multiple prefork and each_run blocks at different locations" do
     Spork.prefork { }
     Spork.each_run { }
-    spec_helper_simulator.should == [:prefork, :each_run]
+    expect(spec_helper_simulator).to eq [:prefork, :each_run]
   end
   
   it "expands a caller line, preserving the line number" do
-    Spork.send(:expanded_caller, "/boo/../yah.rb:31").should == "/yah.rb:31"
+    expect(Spork.send(:expanded_caller, "/boo/../yah.rb:31")).to eq "/yah.rb:31"
   end
   
   describe "#using_spork?" do
     it "returns true if Spork is being used" do
-      Spork.using_spork?.should be_false
+      expect(Spork.using_spork?).to be_false
       Spork.exec_prefork { }
-      Spork.using_spork?.should be_true
+      expect(Spork.using_spork?).to be_true
     end
   end
 
@@ -106,15 +106,15 @@ describe Spork do
       @trap_test.hello
       @trap_test.goodbye
       Spork.exec_each_run
-      TrapTest.output.should == ['goodbye', 'hello']
+      expect(TrapTest.output).to eq ['goodbye', 'hello']
     end
     
     it "works with methods that have punctuation" do
       Spork.trap_method(TrapTest, :say_something!)
       @trap_test.say_something!
-      TrapTest.output.should == []
+      expect(TrapTest.output).to eq []
       Spork.exec_each_run
-      TrapTest.output.should == ['something']
+      expect(TrapTest.output).to eq ['something']
     end
   end
   
@@ -147,7 +147,7 @@ describe Spork do
       TrapTest.hello
       TrapTest.goodbye
       Spork.exec_each_run
-      TrapTest.output.should == ['goodbye', 'hello']
+      expect(TrapTest.output).to eq ['goodbye', 'hello']
     end
   end
 end


### PR DESCRIPTION
Updated specs to use expect syntax.
As you may well know, using 'expect' over 'should' is a recommended practice because of dealing with delegate/proxy objects as detailed in http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax.
As detailed in the blog post "In the future, we plan to change the defaults so that only expect is available unless you explicitly enable should. We may do this as soon as RSpec 3.0, but we want to give users plenty of time to get acquainted with it."
I noticed that expect is now being used in many of the major gems that use rspec. 
I changed the pattern matchers from =~ to match() or match_array() as required for this change and while at it I also took the opportunity to change the == format to eq as recommended in the post. 
All previously passing tests still pass after this change.
I have tried to observe the existing style.  The only exception is some blank spaces on empty lines - but I kept the empty lines themselves.
