### PR TITLE
Server expects the stategy to return the result

### DIFF
--- a/lib/spork/run_strategy/magazine.rb
+++ b/lib/spork/run_strategy/magazine.rb
@@ -96,8 +96,9 @@ class Spork::RunStrategy::Magazine < Spork::RunStrategy
 
     puts "(#{slave.id_num}); slave.run..."; $stdout.flush
     begin
-      slave.run(argv,stderr,stdout)
+      result = slave.run(argv,stderr,stdout)
       puts "   -- (#{slave.id_num});run done"; $stdout.flush
+      result
     ensure
       restart_slave(id)
     end

--- a/lib/spork/run_strategy/magazine/magazine_slave.rb
+++ b/lib/spork/run_strategy/magazine/magazine_slave.rb
@@ -19,8 +19,9 @@ class MagazineSlave
     $stdout, $stderr = stdout, stderr
     Spork.exec_each_run
     load @test_framework.helper_file
-    @test_framework.run_tests(argv, stderr, stdout)
+    result = @test_framework.run_tests(argv, stderr, stdout)
     puts "  <-- Slave(#{@id_num}) run done!"; stdout.flush
+    result
   end
 
   def preload


### PR DESCRIPTION
Spork server expects the strategy to return the test result (https://github.com/sporkrb/spork/blob/master/lib/spork/server.rb#L49).

This prevents the test runner to know if the status of the test run.
