### PR TITLE
Uninitialized constant RSpec::Core::CommandLine

### DIFF
--- a/lib/spork/test_framework/rspec.rb
+++ b/lib/spork/test_framework/rspec.rb
@@ -1,3 +1,5 @@
+require 'rspec/core/version'
+
 class Spork::TestFramework::RSpec < Spork::TestFramework
   DEFAULT_PORT = 8989
   HELPER_FILE = File.join(Dir.pwd, "spec/spec_helper.rb")
@@ -7,9 +9,17 @@ class Spork::TestFramework::RSpec < Spork::TestFramework
       ::Spec::Runner::CommandLine.run(
         ::Spec::Runner::OptionParser.parse(argv, stderr, stdout)
       )
+    elsif rspec3?
+      options = ::RSpec::Core::ConfigurationOptions.new(argv)
+      ::RSpec::Core::Runner.new(options).run(stderr, stdout)
     else
       ::RSpec::Core::CommandLine.new(argv).run(stderr, stdout)
     end
+  end
+
+  def rspec3?
+    return false if !defined?(::RSpec::Core::Version::STRING)
+    ::RSpec::Core::Version::STRING =~ /^3\./
   end
 
   def rspec1?

--- a/lib/spork/test_framework/rspec.rb
+++ b/lib/spork/test_framework/rspec.rb
@@ -1,5 +1,3 @@
-require 'rspec/core/version'
-
 class Spork::TestFramework::RSpec < Spork::TestFramework
   DEFAULT_PORT = 8989
   HELPER_FILE = File.join(Dir.pwd, "spec/spec_helper.rb")


### PR DESCRIPTION
`RSpec::Core::CommandLine` was merged into `RSpec::Core::Runner in 3.0.0.rc1`.  I poked around and added some code that fixed the uninitialized constant error. 

Please note: I was unable run the test suite (even before modifying any code) because I kept getting this error:
`forker.rb:29:in 'write': not opened for writing (IOError)`.  I tried but now I need to move on to other things.  Hope this helps!
