### PR TITLE
Add license to gemspec

### DIFF
--- a/spork.gemspec
+++ b/spork.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   ]
   s.files = ["Gemfile", "README.rdoc", "MIT-LICENSE"] + Dir["lib/**/*"] + Dir["spec/**/*"] + Dir["assets/**/*"] + Dir["features/**/*"]
   s.homepage = %q{http://github.com/sporkrb/spork}
+  s.license = "MIT"
   s.rdoc_options = ["--main", "README.rdoc"]
   s.require_paths = ["lib"]
   s.summary = %q{spork}


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.
