### PR TITLE
fixed rspec1? method to work correctly

### DIFF
--- a/lib/spork/test_framework/rspec.rb
+++ b/lib/spork/test_framework/rspec.rb
@@ -21,6 +21,6 @@ class Spork::TestFramework::RSpec < Spork::TestFramework
   end
 
   def rspec1?
-    defined?(Spec) && !defined?(RSpec)
+    defined?(::Spec) && !defined?(::RSpec)
   end
 end


### PR DESCRIPTION
previous implementation would always return true: declaring `Spork::Test::Framework::RSpec < Spork::TestFramework` causes `defined?(RSpec)` to always be true within the scope of `Spork::Test::Framework::RSpec`. see [this gist](https://gist.github.com/sshao/e8c975ae4a45b2fdf512) for a pure ruby reproduction of this behavior.

the spork spec suite already contains tests for rspec1 support, but did not catch this bug because [the tests stub the `rspec1?` method](https://github.com/sporkrb/spork/blob/224df492657e617a0c93c0319e78f0eefee5b636/spec/spork/test_framework/rspec_spec.rb#L16). I couldn't think of a way to fix the tests to catch this behavior, as it would require removing/stubbing out the `::RSpec` constant for that example, but since the test suite itself uses RSpec 2 to run, removal of `::RSpec` would then break the test runner.
