### PR TITLE
Spellfix wiki page name

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -74,7 +74,7 @@ It will output a lot of stuff.  At the top you'll find a summary of all project 
 
 Some project changes will require a spork restart, and you shouldn't expect them to not (IE: modifying your project gem dependencies or core application config).  Any file that is loaded during Spork start-up will be cached until Spork is restarted.  You can restart spork by sending a USR2 signal to the server process.  This could be automated with a gem such as Kicker (https://github.com/alloy/kicker).  Since a native hook is required for each operating system to efficiently watch for filesystem changes, automatic restarting has not been built into Spork.
 
-You may find this wiki page useful for common ways to battle a variety of common pre-loading issues: http://github.com/sporkrb/spork/wiki/Spork.trap_method-Jujutsu
+You may find this wiki page useful for common ways to battle a variety of common pre-loading issues: http://github.com/sporkrb/spork/wiki/Spork.trap_method-Jujitsu
 
 == Running specs over Spork
 


### PR DESCRIPTION
because it's otherwise going to a "create new page", and this is how it's actually spelled. :)